### PR TITLE
fix mac onclose event

### DIFF
--- a/netpoll_bsd.go
+++ b/netpoll_bsd.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	EpollRead  = syscall.EV_ADD | syscall.EV_EOF
-	EpollClose = uint16(syscall.EV_EOF)
+	EpollRead  = syscall.EV_ADD
+	EpollClose = syscall.EV_ADD | syscall.EV_EOF
 )
 
 type epoll struct {


### PR DESCRIPTION
在mac下开发，发现onClose事件无法触发，随即发现事件定义有问题，另外您这个框架写的很棒，对新手开发很友好.